### PR TITLE
Added support for TBC and alpha versions to updatefield extractor

### DIFF
--- a/Source/Tools/Mangos.Extractor/Functions.cs
+++ b/Source/Tools/Mangos.Extractor/Functions.cs
@@ -24,6 +24,7 @@ using System.Text;
 using System.Windows.Forms;
 using Microsoft.VisualBasic;
 using Microsoft.VisualBasic.CompilerServices;
+using System.Diagnostics;
 
 namespace Mangos.Extractor
 {
@@ -233,17 +234,28 @@ namespace Mangos.Extractor
 
         public static void ExtractUpdateFields()
         {
+            var TBC = 0;
+            var versInfo = FileVersionInfo.GetVersionInfo("Wow.exe");
             var f = new FileStream("wow.exe", FileMode.Open, FileAccess.Read, FileShare.Read, 10000000);
             var r1 = new BinaryReader(f);
             var r2 = new StreamReader(f);
-            var o = new FileStream("Global.UpdateFields.cs", FileMode.Create, FileAccess.Write, FileShare.None, 1024);
+            var o = new FileStream(versInfo.FileMajorPart + "." + versInfo.FileMinorPart + "."+ versInfo.FileBuildPart + "." + versInfo.FilePrivatePart + "_Global.UpdateFields.cs", FileMode.Create, FileAccess.Write, FileShare.None, 1024);
             var w = new StreamWriter(o);
             int FIELD_NAME_OFFSET = SearchInFile(f, "CORPSE_FIELD_PAD");
             int OBJECT_FIELD_GUID = SearchInFile(f, "OBJECT_FIELD_GUID") + 0x400000;
             int FIELD_TYPE_OFFSET = SearchInFile(f, OBJECT_FIELD_GUID);
-            if (FIELD_NAME_OFFSET == -1)
+            #if DEBUG
+            MessageBox.Show("FIELD_NAME_OFFSET " + FIELD_NAME_OFFSET + " OBJECT_FIELD_GUID " + OBJECT_FIELD_GUID + " FIELD_TYPE_OFFSET " + FIELD_TYPE_OFFSET);
+            #endif
+            if (FIELD_NAME_OFFSET == -1) // pre 1.5 vanilla support
             {
                 FIELD_NAME_OFFSET = SearchInFile(f, "CORPSE_FIELD_FLAGS");
+            }
+            if (FIELD_TYPE_OFFSET == -1) // TBC support
+            {
+                OBJECT_FIELD_GUID = SearchInFile(f, "OBJECT_FIELD_GUID") + (0x1A00 + 0x400000);
+                FIELD_TYPE_OFFSET = SearchInFile(f, OBJECT_FIELD_GUID);
+                TBC = 1;
             }
             if (FIELD_NAME_OFFSET == -1 | FIELD_TYPE_OFFSET == -1)
             {
@@ -300,6 +312,8 @@ namespace Mangos.Extractor
                 MessageBox.Show(string.Format("{0} fields extracted.", Names.Count));
                 w.WriteLine("// Auto generated file");
                 w.WriteLine("// {0}", DateAndTime.Now);
+                w.WriteLine("// Patch: " + versInfo.FileMajorPart + "." + versInfo.FileMinorPart + "."+ versInfo.FileBuildPart);
+                w.WriteLine("// Build: " + versInfo.FilePrivatePart);
                 w.WriteLine();
                 string LastFieldType = "";
                 string sName;
@@ -310,6 +324,10 @@ namespace Mangos.Extractor
                 for (int j = 0, loopTo1 = Info.Count - 1; j <= loopTo1; j++)
                 {
                     sName = ReadString(f, Info[j].Name - 0x400000);
+                    if (TBC == 1) // TBC support
+                    {
+                        sName = ReadString(f, Info[j].Name - (0x1A00 + 0x400000));
+                    }
                     if (!string.IsNullOrEmpty(sName))
                     {
                         sField = ToField(sName.Substring(0, sName.IndexOf("_")));
@@ -334,7 +352,27 @@ namespace Mangos.Extractor
 
                             w.WriteLine("Public Enum E" + sField + "Fields");
                             w.WriteLine("{");
-                            if (sField.ToLower() == "container")
+                            #if DEBUG
+                            MessageBox.Show("sField: " + sField  + "\nsName: " + sName);
+                            #endif
+                            if (TBC == 1) // TBC support
+                                if (sField.ToLower() == "item")
+                            {
+                                BasedOn = EndNum["Container"];
+                                BasedOnName = "EContainerFields.CONTAINER_END";
+                            }
+                            else if (sField.ToLower() == "player")
+                            {
+                                BasedOn = EndNum["Unit"];
+                                BasedOnName = "EUnitFields.UNIT_END";
+                            }
+                            else if (sField.ToLower() != "object")
+                            {
+                                BasedOn = EndNum["Object"];
+                                BasedOnName = "EObjectFields.OBJECT_END";
+                            }
+                            if (TBC == 0)
+                                if (sField.ToLower() == "container")
                             {
                                 BasedOn = EndNum["Item"];
                                 BasedOnName = "EItemFields.ITEM_END";

--- a/Source/Tools/Mangos.Extractor/Functions.cs
+++ b/Source/Tools/Mangos.Extractor/Functions.cs
@@ -235,6 +235,7 @@ namespace Mangos.Extractor
         public static void ExtractUpdateFields()
         {
             var TBC = 0;
+            var alpha = 0;
             var versInfo = FileVersionInfo.GetVersionInfo("Wow.exe");
             var f = new FileStream("wow.exe", FileMode.Open, FileAccess.Read, FileShare.Read, 10000000);
             var r1 = new BinaryReader(f);
@@ -250,6 +251,11 @@ namespace Mangos.Extractor
             if (FIELD_NAME_OFFSET == -1) // pre 1.5 vanilla support
             {
                 FIELD_NAME_OFFSET = SearchInFile(f, "CORPSE_FIELD_FLAGS");
+            }
+            if (FIELD_NAME_OFFSET == -1) // alpha support
+            {
+                FIELD_NAME_OFFSET = SearchInFile(f, "CORPSE_FIELD_LEVEL");
+                alpha = 1;
             }
             if (FIELD_TYPE_OFFSET == -1) // TBC support
             {
@@ -331,8 +337,15 @@ namespace Mangos.Extractor
                     if (!string.IsNullOrEmpty(sName))
                     {
                         sField = ToField(sName.Substring(0, sName.IndexOf("_")));
-                        if (sName == "OBJECT_FIELD_CREATED_BY")
+                        if (sName == "OBJECT_FIELD_CREATED_BY" && alpha == 0)
                             sField = "GameObject";
+                        if (sName == "UINT_FIELD_BASESTAT0" || // alpha support
+                            sName == "UINT_FIELD_BASESTAT1" ||
+                            sName == "UINT_FIELD_BASESTAT2" ||
+                            sName == "UINT_FIELD_BASESTAT3" ||
+                            sName == "UINT_FIELD_BASESTAT4" ||
+                            sName == "UINT_FIELD_BYTES_1")
+                            sField = "Unit";
                         if ((LastFieldType ?? "") != (sField ?? ""))
                         {
                             if (!string.IsNullOrEmpty(LastFieldType))


### PR DESCRIPTION
Prior to this, only vanilla patches going down to beta patch 0.6 was supported.
With the added support for alpha, patch 0.5.3 and 0.5.5 now works. (and potentially 0.5.4 if its ever found)
When it comes to the added support for TBC, this allows you to extract updatefields from entire TBC.

This all means that with this update, you will be able to extract updatefields from all patches from 0.5.3 to patch 2.4.3.

I've also included auto outputting patch and build number into both filenames and into written text in each new file, so you don't need to write patch and build numbers yourself.
Outputting build and patch numbers works for every patch except alpha, since alpha doesn't include versions in assemblyinfo. Going forward, this will work for patches above TBC as well.

As to how this all works:
> FIELD_TYPE_OFFSET is only changed in TBC, it's the same through alpha and entire vanilla.
However FIELD_NAME_OFFSET is changed twice in vanilla, once in patch 0.6 and then another time in patch 1.5.

> It first checks FIELD_NAME_OFFSET for 1.5+ (line 245), if it cannot be found it checks for pre 1.5 (line 253), if that cannot be found it checks for FIELD_NAME_OFFSET from pre 0.6 (line 257).

> When it comes to FIELD_TYPE_OFFSET it checks if it can find it (line 246), if it cannot be found it then checks for the TBC location of FIELD_TYPE_OFFSET (line 262).

One note I have to mention about alpha is that in order for it to work, you will have to rename exe from wowclient.exe to wow.exe in order for it to work. This is because wow.exe in alpha is just a login launcher and the real game exe is wowclient.exe.

Many thanks to Brotalia for the code for alpha support and for help in figuring out how the "magic" number attached to FIELD_TYPE_OFFSET (line 256 and line 329) works. (yes, it was even commented as "magic" number in wowds old updatefield extractor)