### PR TITLE
Fix Mangos Test

### DIFF
--- a/src/server/Mangos.Tests/Common/OpcodeTests.cs
+++ b/src/server/Mangos.Tests/Common/OpcodeTests.cs
@@ -53,8 +53,8 @@ public class OpcodeTests
     {
         Assert.Equal((Opcodes)0x81, Opcodes.CMSG_GUILD_CREATE);
         Assert.Equal((Opcodes)0x82, Opcodes.CMSG_GUILD_INVITE);
-        Assert.Equal((Opcodes)0x89, Opcodes.CMSG_GUILD_QUERY);
-        Assert.Equal((Opcodes)0x54, Opcodes.CMSG_GUILD_DISBAND);
+        Assert.Equal((Opcodes)0x54, Opcodes.CMSG_GUILD_QUERY);
+        Assert.Equal((Opcodes)0x8F, Opcodes.CMSG_GUILD_DISBAND);
     }
 
     [Fact]


### PR DESCRIPTION
Fix compiling issue when using the **dotnet test** command.

I have noticed the opcode packet data for **CMSG_GUILD_QUERY** and **CMSG_GUILD_DISBAND** were not using the correct data and was resulting a mismatch between the two.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/MangosSharp/109)
<!-- Reviewable:end -->
