### PR TITLE
CA2022: Avoid inexact read with Stream.Read

### DIFF
--- a/src/server/Mangos.Cluster/Handlers/WC_Handlers_Auth.cs
+++ b/src/server/Mangos.Cluster/Handlers/WC_Handlers_Auth.cs
@@ -225,7 +225,9 @@ public class WcHandlersAuth
                 {
                     int read = fs.Read(fb, offset, remaining);
                     if (read == 0)
+                    {
                         break;
+                    }
 
                     offset += read;
                     remaining -= read;

--- a/src/server/Mangos.Cluster/Handlers/WC_Handlers_Auth.cs
+++ b/src/server/Mangos.Cluster/Handlers/WC_Handlers_Auth.cs
@@ -207,16 +207,35 @@ public class WcHandlersAuth
         PacketClass addOnsEnable = new(Opcodes.SMSG_ADDON_INFO);
         for (int i = 0, loopTo1 = addOnsNames.Count - 1; i <= loopTo1; i++)
         {
-            if (File.Exists(string.Format(@"interface\{0}.pub", addOnsNames[i])) && addOnsHashes[i] != 0x1C776D01U)
+            var path = string.Format(@"interface\{0}.pub", addOnsNames[i]);
+            if (File.Exists(path) && addOnsHashes[i] != 0x1C776D01U)
             {
                 // We have hash data
-                addOnsEnable.AddInt8(2);                    // AddOn Type [1-enabled, 0-banned, 2-blizzard]
-                addOnsEnable.AddInt8(1);                    // Unk
-                FileStream fs = new(string.Format(@"interface\{0}.pub", addOnsNames[i]), FileMode.Open, FileAccess.Read, FileShare.Read, 258, FileOptions.SequentialScan);
-                var fb = new byte[257];
-                fs.Read(fb, 0, 257);
+                addOnsEnable.AddInt8(2); // AddOn Type [1-enabled, 0-banned, 2-blizzard]
+                addOnsEnable.AddInt8(1); // Unk
 
-                // NOTE: Read from file
+                using FileStream fs = new(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.SequentialScan);
+
+                var fb = new byte[257];
+
+                int offset = 0;
+                int remaining = fb.Length;
+
+                while (remaining > 0)
+                {
+                    int read = fs.Read(fb, offset, remaining);
+                    if (read == 0)
+                        break;
+
+                    offset += read;
+                    remaining -= read;
+                }
+
+                if (offset < fb.Length)
+                {
+                    Array.Clear(fb, offset, fb.Length - offset);
+                }
+
                 addOnsEnable.AddByteArray(fb);
                 addOnsEnable.AddInt32(0);
                 addOnsEnable.AddInt8(0);
@@ -224,8 +243,8 @@ public class WcHandlersAuth
             else
             {
                 // We don't have hash data or already sent to client
-                addOnsEnable.AddInt8(2);                    // AddOn Type [1-enabled, 0-banned, 2-blizzard]
-                addOnsEnable.AddInt8(1);                    // Unk
+                addOnsEnable.AddInt8(2); // AddOn Type [1-enabled, 0-banned, 2-blizzard]
+                addOnsEnable.AddInt8(1); // Unk
                 addOnsEnable.AddInt32(0);
                 addOnsEnable.AddInt16(0);
             }


### PR DESCRIPTION
Fix CA2022 warning within the Authentication Handler.

Problem Code:
`
fs.Read(fb, 0, 257);
`
The line of code is never checked.

Reference:
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2022

**Note:**
**This will need some testing to ensure everything is still working as it should**.
I can't test this as I don't have the proper client.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/MangosSharp/111)
<!-- Reviewable:end -->
