### PR TITLE
Restore MySQL Connection Settings

### DIFF
--- a/src/server/Mangos.Common/Globals/MangosGlobalConstants.cs
+++ b/src/server/Mangos.Common/Globals/MangosGlobalConstants.cs
@@ -36,9 +36,9 @@ public class MangosGlobalConstants
     public readonly int RevisionDbCharactersStructure;
     public readonly int RevisionDbCharactersContent;
 
-    public readonly int RevisionDbMangosVersion = 21;
-    public readonly int RevisionDbMangosStructure = 7;
-    public readonly int RevisionDbMangosContent = 77;
+    public readonly int RevisionDbMangosVersion = 1;
+    public readonly int RevisionDbMangosStructure;
+    public readonly int RevisionDbMangosContent;
 
     public readonly int RevisionDbRealmVersion = 21;
     public readonly int RevisionDbRealmStructure = 2;

--- a/src/server/Mangos.Configuration/ConfigurationLoader.cs
+++ b/src/server/Mangos.Configuration/ConfigurationLoader.cs
@@ -62,20 +62,11 @@ internal sealed class ConfigurationLoader
 
     private static void ApplyEnvironmentOverrides(JsonNode root)
     {
-        OverrideString(root, "AccountDataBaseConnectionString", $"{EnvironmentVariablePrefix}ACCOUNT_DB");
+        OverrideString(root, "Realm", "AccountDatabase", $"{EnvironmentVariablePrefix}ACCOUNT_DB");
         OverrideString(root, "Realm", "RealmServerEndpoint", $"{EnvironmentVariablePrefix}REALM_ENDPOINT");
         OverrideString(root, "Cluster", "ClusterServerEndpoint", $"{EnvironmentVariablePrefix}CLUSTER_ENDPOINT");
         OverrideString(root, "Cluster", "ClusterListenAddress", $"{EnvironmentVariablePrefix}CLUSTER_LISTEN_ADDRESS");
         OverrideString(root, "World", "ClusterConnectHost", $"{EnvironmentVariablePrefix}WORLD_CLUSTER_HOST");
-    }
-
-    private static void OverrideString(JsonNode root, string key, string envVar)
-    {
-        var value = Environment.GetEnvironmentVariable(envVar);
-        if (value != null)
-        {
-            root[key] = value;
-        }
     }
 
     private static void OverrideString(JsonNode root, string section, string key, string envVar)
@@ -91,29 +82,45 @@ internal sealed class ConfigurationLoader
     {
         var errors = new List<string>();
 
-        if (string.IsNullOrWhiteSpace(config.AccountDataBaseConnectionString))
-            errors.Add("AccountDataBaseConnectionString is required");
+        if (string.IsNullOrWhiteSpace(config.Realm.AccountDatabase))
+        {
+            errors.Add("Realm.AccountDatabase is required");
+        }
 
         if (string.IsNullOrWhiteSpace(config.Realm.RealmServerEndpoint))
+        {
             errors.Add("Realm.RealmServerEndpoint is required");
+        }
 
         if (string.IsNullOrWhiteSpace(config.Cluster.ClusterServerEndpoint))
+        {
             errors.Add("Cluster.ClusterServerEndpoint is required");
+        }
 
         if (config.Cluster.ClusterListenPort <= 0 || config.Cluster.ClusterListenPort > 65535)
+        {
             errors.Add($"Cluster.ClusterListenPort must be between 1 and 65535, got {config.Cluster.ClusterListenPort}");
+        }
 
         if (config.Cluster.ServerPlayerLimit < 0)
+        {
             errors.Add("Cluster.ServerPlayerLimit cannot be negative");
+        }
 
         if (config.World.ClusterConnectPort <= 0 || config.World.ClusterConnectPort > 65535)
+        {
             errors.Add($"World.ClusterConnectPort must be between 1 and 65535, got {config.World.ClusterConnectPort}");
+        }
 
         if (config.World.XPRate < 0)
+        {
             errors.Add("World.XPRate cannot be negative");
+        }
 
         if (config.World.MapResolution < 64 || config.World.MapResolution > 256)
+        {
             errors.Add($"World.MapResolution must be between 64 and 256, got {config.World.MapResolution}");
+        }
 
         if (errors.Count > 0)
         {

--- a/src/server/Mangos.Configuration/MangosConfiguration.cs
+++ b/src/server/Mangos.Configuration/MangosConfiguration.cs
@@ -20,10 +20,6 @@ namespace Mangos.Configuration;
 
 public sealed class MangosConfiguration
 {
-    public required string AccountDataBaseConnectionString { get; init; }
-    public string? CharacterDataBaseConnectionString { get; init; }
-    public string? WorldDataBaseConnectionStrings { get; init; }   
-
     public required RealmConfiguration Realm
     {
         get; init;

--- a/src/server/Mangos.Configuration/RealmConfiguration.cs
+++ b/src/server/Mangos.Configuration/RealmConfiguration.cs
@@ -24,4 +24,9 @@ public sealed class RealmConfiguration
     {
         get; init;
     }
+
+    public required string AccountDatabase
+    {
+        get; init;
+    }
 }

--- a/src/server/Mangos.Configuration/configuration.json
+++ b/src/server/Mangos.Configuration/configuration.json
@@ -1,7 +1,7 @@
 ﻿{
-  "AccountDataBaseConnectionString": "Server=localhost;Port=3306;User ID=root;Password=rootpass;Database=mangosVBaccounts;Compress=false;Connection Timeout=5;",
   "Realm": {
-    "RealmServerEndpoint": "127.0.0.1:3724"
+    "RealmServerEndpoint": "127.0.0.1:3724",
+    "AccountDatabase": "root;rootpass;localhost;3306;mangosVBaccounts;MariaDB"
   },
   "Cluster": {
     "ClusterServerEndpoint": "127.0.0.1:8085",

--- a/src/server/Mangos.Configuration/configuration.json
+++ b/src/server/Mangos.Configuration/configuration.json
@@ -1,25 +1,25 @@
 ﻿{
   "Realm": {
     "RealmServerEndpoint": "127.0.0.1:3724",
-    "AccountDatabase": "root;rootpass;localhost;3306;mangosVBaccounts;MariaDB"
+    "AccountDatabase": "root;rootpass;localhost;3306;mangosSharpaccounts;MariaDB"
   },
   "Cluster": {
     "ClusterServerEndpoint": "127.0.0.1:8085",
     "ClusterListenAddress": "127.0.0.1",
     "ClusterListenPort": 50001,
     "ServerPlayerLimit": 100,
-    "AccountDatabase": "root;rootpass;localhost;3306;mangosVBaccounts;MariaDB",
-    "CharacterDatabase": "root;rootpass;localhost;3306;mangosVBcharacters;MariaDB",
-    "WorldDatabase": "root;rootpass;localhost;3306;mangosVBworld;MariaDB"
+    "AccountDatabase": "root;rootpass;localhost;3306;mangosSharpaccounts;MariaDB",
+    "CharacterDatabase": "root;rootpass;localhost;3306;mangosSharpcharacters;MariaDB",
+    "WorldDatabase": "root;rootpass;localhost;3306;mangosSharpworld;MariaDB"
   },
   "World": {
     "ClusterConnectHost": "127.0.0.1",
     "ClusterConnectPort": 50001,
     "LocalConnectHost": "127.0.0.1",
     "LocalConnectPort": 50002,
-    "AccountDatabase": "root;rootpass;localhost;3306;mangosVBaccounts;MariaDB",
-    "CharacterDatabase": "root;rootpass;localhost;3306;mangosVBcharacters;MariaDB",
-    "WorldDatabase": "root;rootpass;localhost;3306;mangosVBworld;MariaDB",
+    "AccountDatabase": "root;rootpass;localhost;3306;mangosSharpaccounts;MariaDB",
+    "CharacterDatabase": "root;rootpass;localhost;3306;mangosSharpcharacters;MariaDB",
+    "WorldDatabase": "root;rootpass;localhost;3306;mangosSharpworld;MariaDB",
     "Maps": [ 1, 0 ],
     "ScriptsCompiler": [
       "System.dll",

--- a/src/server/Mangos.MySql/ConnectionFactory.cs
+++ b/src/server/Mangos.MySql/ConnectionFactory.cs
@@ -36,7 +36,7 @@ internal sealed class ConnectionFactory
 
     public AccountConnection ConnectToAccountDataBase()
     {
-        var connectionString = mangosConfiguration.AccountDataBaseConnectionString;
+        var connectionString = BuildConnectionString(mangosConfiguration.Realm.AccountDatabase, "Account");
         if (string.IsNullOrWhiteSpace(connectionString))
         {
             throw new InvalidOperationException("Account database connection string is not configured");
@@ -68,7 +68,7 @@ internal sealed class ConnectionFactory
 
     public CharacterConnection ConnectToCharacterDataBase()
     {
-        var connectionString = mangosConfiguration.CharacterDataBaseConnectionString;
+        var connectionString = BuildConnectionString(mangosConfiguration.Cluster.CharacterDatabase, "Character");
         if (string.IsNullOrWhiteSpace(connectionString))
         {
             throw new InvalidOperationException("Character database connection string is not configured");
@@ -100,7 +100,7 @@ internal sealed class ConnectionFactory
 
     public WorldConnection ConnectToWorldDataBase()
     {
-        var connectionString = mangosConfiguration.WorldDataBaseConnectionStrings;
+        var connectionString = BuildConnectionString(mangosConfiguration.Cluster.WorldDatabase, "World");
         if (string.IsNullOrWhiteSpace(connectionString))
         {
             throw new InvalidOperationException("World database connection string is not configured");
@@ -128,6 +128,25 @@ internal sealed class ConnectionFactory
             mySqlConnection?.Dispose();
             throw;
         }
+    }
+
+    private string BuildConnectionString(string databaseConfig, string databaseName)
+    {
+        // Format: user;pass;host;port;db;type
+        var parts = databaseConfig.Split(';');
+        if (parts.Length < 5)
+        {
+            logger.Error($"Invalid {databaseName} database configuration format. Expected: user;pass;host;port;db;type");
+            return string.Empty;
+        }
+
+        var user = parts[0];
+        var pass = parts[1];
+        var host = parts[2];
+        var port = parts[3];
+        var db = parts[4];
+
+        return $"Server={host};Port={port};User ID={user};Password={pass};Database={db};Compress=false;Connection Timeout=5;";
     }
 
     private bool TestConnection(MySqlConnection connection)

--- a/src/server/Mangos.MySql/DbVersionChecker.cs
+++ b/src/server/Mangos.MySql/DbVersionChecker.cs
@@ -144,57 +144,57 @@ public class DbVersionChecker
         // Perfect match
         if (actual.Version == expected.Version &&  actual.Structure == expected.Structure && actual.Content == expected.Content)
         {
-            _logger.Database($"Database version matched for '{dbName}'");
+            _logger?.Database($"Database version matched for '{dbName}'");
             return true;
         }
 
         // Content mismatch but compatible (warning level)
         if (actual.Version == expected.Version && actual.Structure == expected.Structure && actual.Content != expected.Content)
         {
-            _logger.Warning("--------------------------------------------------------------");
-            _logger.Warning("-- WARNING: CONTENT VERSION MISMATCH                        --");
-            _logger.Warning("--------------------------------------------------------------");
-            _logger.Warning($"Your database '{dbName}' requires updating.");
-            _logger.Warning($"You have: Rev{actual.Version}.{actual.Structure}.{actual.Content}, " +
+            _logger?.Warning("--------------------------------------------------------------");
+            _logger?.Warning("-- WARNING: CONTENT VERSION MISMATCH                        --");
+            _logger?.Warning("--------------------------------------------------------------");
+            _logger?.Warning($"Your database '{dbName}' requires updating.");
+            _logger?.Warning($"You have: Rev{actual.Version}.{actual.Structure}.{actual.Content}, " +
                          $"however the core expects Rev{expected.Version}.{expected.Structure}.{expected.Content}");
-            _logger.Warning("The server will run, but you may be missing some database fixes");
+            _logger?.Warning("The server will run, but you may be missing some database fixes");
             return true;
         }
 
         // Version or structure mismatch (fatal)
-        _logger.Critical("--------------------------------------------------------------");
-        _logger.Critical("-- CRITICAL ERROR: DATABASE VERSION MISMATCH                --");
-        _logger.Critical("--------------------------------------------------------------");
-        _logger.Critical($"Your database '{dbName}' requires updating.");
-        _logger.Critical($"You have: Rev{actual.Version}.{actual.Structure}.{actual.Content}, " +
+        _logger?.Critical("--------------------------------------------------------------");
+        _logger?.Critical("-- CRITICAL ERROR: DATABASE VERSION MISMATCH                --");
+        _logger?.Critical("--------------------------------------------------------------");
+        _logger?.Critical($"Your database '{dbName}' requires updating.");
+        _logger?.Critical($"You have: Rev{actual.Version}.{actual.Structure}.{actual.Content}, " +
                          $"but the core requires Rev{expected.Version}.{expected.Structure}.{expected.Content}");
-        _logger.Critical("The server is unable to run until the required updates are applied.");
-        _logger.Critical("--------------------------------------------------------------");
-        _logger.Critical($"Please apply all updates after Rev{expected.Version}.{expected.Structure}.{expected.Content}");
-        _logger.Critical("These updates are located in the sql/updates folder.");
-        _logger.Critical("--------------------------------------------------------------");
+        _logger?.Critical("The server is unable to run until the required updates are applied.");
+        _logger?.Critical("--------------------------------------------------------------");
+        _logger?.Critical($"Please apply all updates after Rev{expected.Version}.{expected.Structure}.{expected.Content}");
+        _logger?.Critical("These updates are located in the sql/updates folder.");
+        _logger?.Critical("--------------------------------------------------------------");
         return false;
     }
 
     // Logs when the database version check fails.
     private void LogDatabaseCheckFailure(string dbName, string reason)
     {
-        _logger.Failed("--------------------------------------------------------------");
-        _logger.Failed("-- DATABASE VERSION CHECK FAILURE                           --");
-        _logger.Failed("--------------------------------------------------------------");
-        _logger.Failed($"Failed to check version for database '{dbName}': {reason}");
-        _logger.Failed("--------------------------------------------------------------");
+        _logger?.Failed("--------------------------------------------------------------");
+        _logger?.Failed("-- DATABASE VERSION CHECK FAILURE                           --");
+        _logger?.Failed("--------------------------------------------------------------");
+        _logger?.Failed($"Failed to check version for database '{dbName}': {reason}");
+        _logger?.Failed("--------------------------------------------------------------");
     }
 
     // Logs when the db_version table is missing.
     private void LogMissingVersionTable(string dbName, DbVersionInfo expected)
     {
-        _logger.Alert("--------------------------------------------------------------");
-        _logger.Alert("-- MISSING VERSION TABLE                                    --");
-        _logger.Alert("--------------------------------------------------------------");
-        _logger.Alert($"The table 'db_version' is missing in database '{dbName}'");
-        _logger.Alert("This database is likely not properly set up or is too old.");
-        _logger.Alert($"The core requires database schema Rev{expected.Version}.{expected.Structure}.{expected.Content}");
-        _logger.Alert("--------------------------------------------------------------");
+        _logger?.Alert("--------------------------------------------------------------");
+        _logger?.Alert("-- MISSING VERSION TABLE                                    --");
+        _logger?.Alert("--------------------------------------------------------------");
+        _logger?.Alert($"The table 'db_version' is missing in database '{dbName}'");
+        _logger?.Alert("This database is likely not properly set up or is too old.");
+        _logger?.Alert($"The core requires database schema Rev{expected.Version}.{expected.Structure}.{expected.Content}");
+        _logger?.Alert("--------------------------------------------------------------");
     }
 }

--- a/src/server/Mangos.MySql/MySqlModule.cs
+++ b/src/server/Mangos.MySql/MySqlModule.cs
@@ -30,6 +30,8 @@ public sealed class MySqlModule : Module
     {
         builder.RegisterType<ConnectionFactory>().SingleInstance();
         builder.Register(context => context.Resolve<ConnectionFactory>().ConnectToAccountDataBase()).SingleInstance();
+        builder.Register(context => context.Resolve<ConnectionFactory>().ConnectToCharacterDataBase()).SingleInstance();
+        builder.Register(context => context.Resolve<ConnectionFactory>().ConnectToWorldDataBase()).SingleInstance();
 
         RegisterQueries(builder);
     }


### PR DESCRIPTION
**Changes Made**:
- Restore original connection strings for MySQL database
- Removed silly MySQL connection string method in "configuration.json" that was added in by another user that should have never been changed.
- Reset Character and Mangos (World) Revision to default of Rel1.0.0.
   Note: This is temp as I rebuild the Character and World Database for Mangos C#. Realm Revision will remain the same at Rel21.2.1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/MangosSharp/118)
<!-- Reviewable:end -->
